### PR TITLE
Possibly a typo : 'make' vs 'make install'?

### DIFF
--- a/ReadMe.html
+++ b/ReadMe.html
@@ -95,7 +95,7 @@ $ make install</code></pre>
 
 <pre><code>$ cd src/
 $ cmake .
-$ make install</code></pre>
+$ make</code></pre>
 
 <h2 id='execution_instructions'>Execution instructions</h2>
 

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -105,7 +105,7 @@ The installation is simple:
 
     $ cd src/
     $ cmake .
-    $ make install
+    $ make
      
 
 Execution instructions


### PR DESCRIPTION
Hi Andrea,
Could you please check whether this pull-request is valid? `make install` doesn't have a valid build rule I guess. Following is the build commands' output when I tried building the calibration package.
System details : Ubuntu 16.04, CMake 3.5.1, CSM installed.

```
➜  make
[ 21%] Built target verifier
[ 32%] Built target gsl_jacobian_test
[ 46%] Built target synchronizer
[ 64%] Built target solver
[ 71%] Built target test_json
[100%] Built target solver2
➜  make install
make: *** No rule to make target 'install'.  Stop.
```

P.S I found your paper on calibrating sensor parameters and robot's odometry interesting. Looking forward to experiment with it :)